### PR TITLE
Use LC_ALL=C when comparing program output

### DIFF
--- a/lscd
+++ b/lscd
@@ -250,7 +250,7 @@ lscd_base () {
     openfile () {
         f="$1"
         [ -z "$f" ] && return
-        filetype="$(stat -Lc %F "$f")"
+        filetype="$(LC_ALL=C stat -Lc %F "$f")"
         case "$filetype" in
             directory)
                 movedir "$f";;


### PR DESCRIPTION
Previously entering a directory was only possible with LANG equal to
something English.